### PR TITLE
Generate SCSS source maps

### DIFF
--- a/themes/hugo-theme-novela/layouts/partials/head/head.html
+++ b/themes/hugo-theme-novela/layouts/partials/head/head.html
@@ -3,7 +3,8 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="icon" href="/images/favicon.svg">
-    {{ $style := resources.Get "scss/global.scss" | toCSS | minify | fingerprint }}
+    {{ $options := dict "enableSourceMap" true "outputStyle" "compressed" }}
+    {{ $style := resources.Get "scss/global.scss" | resources.ToCSS $options | fingerprint }}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}">
     {{ $prism := resources.Get "css/prism.css" }}
     <link rel="stylesheet" href="{{ $prism.RelPermalink }}" />


### PR DESCRIPTION
Damit werden Source Maps bei allen Builds erstellt - egal, ob lokal, auf forestry oder netlify.

---

Man könnte z.B.

```go
$options := dict "enableSourceMap" (ne (getenv "HUGO_ENV") "production") "outputStyle" "compressed"
```

benutzen, damit Source Maps nicht erstellt werden, wenn `HUGO_ENV` auf `"production"` gestellt ist. Damit können wir erreichen, dass auf Netlify keine Source Maps erstellt werden. Dazu benötigen wir zusätzlich eine `netlify.toml` im Root-Verzeichnis von diesem Repo mit folgendem Inhalt:

```toml
[build.environment]
HUGO_ENV = "production"
```
---

Plus: Ich verwende hier `outputStyle "compressed"` anstelle von dem generischeren `resources.Minify`.

> Setting `outputStyle` to `compressed` will handle`SASS/SCSS files minification better than the more generic `[resources.Minify](https://gohugo.io/hugo-pipes/minification/)`.

Siehe https://gohugo.io/hugo-pipes/scss-sass für die Dokumentation dazu.

---

Notion: https://www.notion.so/Enable-Source-Maps-f9c9e157ea5a4d6d80dcc1b5710c611e